### PR TITLE
remove unnecessary conditional from equals method

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1459,7 +1459,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         >>> df.equals(different_data_type)
         False
         """
-        if not (isinstance(other, type(self)) or isinstance(self, type(other))):
+        if not (isinstance(other, type(self)):
             return False
         other = cast(NDFrame, other)
         return self._mgr.equals(other._mgr)


### PR DESCRIPTION
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

Currently, the `equals` method has two conditional expressions. The second conditional expression is not only a duplicate of the first one, but because it does not have the "not" operator in front of it like the first conditional expression does, it causes incorrect behavior of the equals function. 